### PR TITLE
Add Button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "medspace-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.487.0",
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "tailwind-merge": "^3.2.0",
         "tw-animate-css": "^1.2.5"
       },
@@ -3298,6 +3300,37 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "dev": true
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
+      "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -4925,7 +4958,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -7469,7 +7502,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -12168,6 +12201,14 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.487.0",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "tailwind-merge": "^3.2.0",
     "tw-animate-css": "^1.2.5"
   },

--- a/src/components/Button/Button.stories.ts
+++ b/src/components/Button/Button.stories.ts
@@ -1,0 +1,63 @@
+import { Meta, StoryObj } from "@storybook/react";
+import Button from "./Button";
+
+const meta: Meta<typeof Button> = {
+  title: "Components/Button",
+  component: Button,
+  tags: ["autodocs"],
+  args: {
+    children: "Button",
+    onClick: () => alert("Button clicked!"),
+    icon: null,
+    size: "default",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "blue", "outline", "danger"],
+      defaultValue: "primary",
+    },
+    size: {
+      control: "select",
+      options: ["default", "small", "large", "fill"],
+      defaultValue: "default",
+    },
+    icon: {
+      control: false,
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {};
+
+export const Blue: Story = {
+  args: {
+    variant: "blue",
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: "outline",
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    variant: "danger",
+  },
+};
+
+export const Icon: Story = {
+  args: {
+    icon: "🔔",
+  },
+};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,56 @@
+import { cn } from "@/lib/utils";
+
+type ButtonProps = {
+  /** Text to display in the Button */
+  children: React.ReactNode;
+  /** Function to call when the Button is clicked */
+  onClick?: () => void;
+  /** Variant of the Button */
+  variant?: "primary" | "blue" | "outline" | "danger";
+  /** Icon to display in the Button, tipically a React Icon */
+  icon?: React.ReactNode;
+  /** Size of the Button */
+  size?: "default" | "small" | "large" | "fill";
+  /** Other classes */
+  className?: string;
+};
+
+const Button = ({
+  children,
+  onClick,
+  variant = "primary",
+  icon,
+  size = "default",
+  className,
+}: ButtonProps) => {
+  const variantMap = {
+    primary: "bg-blue-500 text-white hover:bg-blue-600",
+    blue: "bg-blue-200 text-blue-600 font-extrabold hover:bg-blue-300",
+    outline: "bg-transparent text-black border border-black hover:bg-gray-100",
+    danger: "bg-red-500 text-white hover:bg-red-600",
+  };
+
+  const sizeMap = {
+    small: "text-sm px-4 py-1",
+    default: "text-md px-6 py-2",
+    large: "text-lg px-8 py-3",
+    fill: "flex-1 text-sm px-6 py-3",
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "items-center inline-flex justify-center gap-2 rounded-md text-sm px-6 py-2 cursor-pointer transition-all duration-150",
+        variantMap[variant],
+        sizeMap[size],
+        className
+      )}
+    >
+      {icon && <span className="mr-1">{icon}</span>}
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Button';

--- a/src/components/LandlordClinicListItem/LandlordClinicListItem.stories.ts
+++ b/src/components/LandlordClinicListItem/LandlordClinicListItem.stories.ts
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from "@storybook/react";
+import LandlordClinicListItem from "./LandlordClinicListItem";
+
+const meta: Meta<typeof LandlordClinicListItem> = {
+  title: "Components/LandlordClinicListItem",
+  component: LandlordClinicListItem,
+  tags: ["autodocs"],
+  args: {
+    clinicName: "Consultorio Médico Moderno",
+    clinicState: "Aguascalientes",
+    clinicImageURL:
+      "https://upload.wikimedia.org/wikipedia/commons/b/b3/Double_hospital_room._Ulan-Ude%2C_Buryatia.jpg",
+    numberOfClinicRequests: 12,
+    onClickEdit: () => {
+      alert("Edit clicked");
+    },
+    onClickRequests: () => {
+      alert("Requests clicked");
+    },
+    onShareClick: () => {
+      alert("Share clicked");
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LandlordClinicListItem>;
+
+export const Primary: Story = {};

--- a/src/components/LandlordClinicListItem/LandlordClinicListItem.tsx
+++ b/src/components/LandlordClinicListItem/LandlordClinicListItem.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { IoIosNotifications } from "react-icons/io";
+import { MdEdit } from "react-icons/md";
+import { HiShare } from "react-icons/hi2";
+
+import Button from "@/components/Button";
+
+type ClinicListItemProps = {
+  /** Name of the clinic */
+  clinicName: string;
+  /** State of the clinic */
+  clinicState: string;
+  /** Url to the clinic's main image */
+  clinicImageURL: string;
+  /** Number of rent requests of clinic */
+  numberOfClinicRequests: number;
+  /** Function to call when the requests button is clicked */
+  onClickRequests: () => void;
+  /** Function to call when the edit button is clicked */
+  onClickEdit: () => void;
+  /** Function to call when the share button is clicked */
+  onShareClick: () => void;
+};
+
+const LandlordClinicListItem = ({
+  clinicName,
+  clinicState,
+  clinicImageURL,
+  numberOfClinicRequests,
+  onClickRequests,
+  onClickEdit,
+  onShareClick,
+}: ClinicListItemProps) => {
+  return (
+    <div className="flex flex-1 flex-col gap-8 p-8 items-center justify-between shadow-[0_0_5px_rgba(0,0,0,0.1)] rounded-sm md:flex-row md:justify-between md:px-6 md:py-2 ">
+      <div className="flex flex-row items-center gap-4">
+        <img
+          src={clinicImageURL}
+          alt="Clinic"
+          className="w-16 h-16 object-cover rounded-full"
+        />
+        <p className="text-lg font-normal">{clinicName}</p>
+      </div>
+      <div className="hidden md:block">
+        <p className="text-md font-light">{clinicState}</p>
+      </div>
+      <div className="flex flex-col gap-4 md:flex-row md:items-center">
+        <HiShare
+          className="cursor-pointer w-6 h-6 fill-gray-600 transition-transform duration-200 hover:-rotate-12"
+          onClick={() => onShareClick()}
+        />
+        <Button icon={<IoIosNotifications />} onClick={() => onClickRequests()}>
+          {numberOfClinicRequests} Requests
+        </Button>
+        <Button
+          icon={<MdEdit />}
+          variant="outline"
+          onClick={() => onClickEdit()}
+        >
+          Edit
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default LandlordClinicListItem;

--- a/src/components/LandlordClinicListItem/index.ts
+++ b/src/components/LandlordClinicListItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LandlordClinicListItem";


### PR DESCRIPTION
## Summary 
This MR introduces a reusable Button UI component with customizable props and its relevant documentation, as well as the landlord clinic list item component that uses the new Button.

## Context
This is part of the following task:
[Jira Board](https://paez-tec.atlassian.net/browse/MED-71?atlOrigin=eyJpIjoiNzYyM2NiZDY0M2QwNDFiZmIyYjlmZGQ3OTE2ODFhYjYiLCJwIjoiaiJ9)

## Changes
- Add Button ui component and documentation
- Add LandlordClinicListItem component and documentation

## Test Plan
The components render properly in each of its variants:

<img width="291" alt="Captura de pantalla 2025-04-09 a la(s) 12 15 16 a m" src="https://github.com/user-attachments/assets/9d39612f-52bf-4e94-904c-1e9df72c1be3" />

<img width="955" alt="Captura de pantalla 2025-04-09 a la(s) 12 47 21 p m" src="https://github.com/user-attachments/assets/25c679f0-2421-4601-91d4-2beca7405d76" />

