### PR TITLE
Feature/create request status modal

### DIFF
--- a/src/components/CreateRequestStatusModal/CreateRequestStatusModal.stories.ts
+++ b/src/components/CreateRequestStatusModal/CreateRequestStatusModal.stories.ts
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from "@storybook/react";
+import CreateRequestStatusModal from "./CreateRequestStatusModal";
+
+const meta: Meta<typeof CreateRequestStatusModal> = {
+  title: "Components/CreateRequestStatusModal",
+  component: CreateRequestStatusModal,
+  tags: ["autodocs"],
+  args: {
+    icon: "success",
+    onClose: () => alert("Modal closed"),
+  },
+  argTypes: {
+    icon: {
+      control: {
+        type: "select",
+        options: ["success", "error"],
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CreateRequestStatusModal>;
+
+export const Success: Story = {
+  args: {
+    icon: "success",
+  },
+};
+
+export const Error: Story = {
+  args: {
+    icon: "error",
+  },
+};

--- a/src/components/CreateRequestStatusModal/CreateRequestStatusModal.tsx
+++ b/src/components/CreateRequestStatusModal/CreateRequestStatusModal.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+interface CreateRequestStatusModalProps {
+  icon: "success" | "error"; 
+  onClose: () => void; 
+}
+
+const CreateRequestStatusModal: React.FC<CreateRequestStatusModalProps> = ({
+  icon,
+  onClose,
+}) => {
+  const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Si el usuario hace clic en el fondo, cierra el modal
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const message = icon === "success" ? "Request Sent" : "Request Failed";
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      onClick={handleBackgroundClick} 
+    >
+      <div className="bg-white rounded-lg shadow-lg p-6 w-80 flex flex-col items-center">
+        {/* Icono personalizado */}
+        {icon === "success" ? (
+          <img
+            src="/success.png"
+            alt="Success icon"
+            className="w-16 h-16 mb-4"
+          />
+        ) : (
+          <img
+            src="/error.png"
+            alt="Error icon"
+            className="w-16 h-16 mb-4"
+          />
+        )}
+
+        {/* Mensaje */}
+        <p className="text-center text-lg font-medium">{message}</p>
+      </div>
+    </div>
+  );
+};
+
+export default CreateRequestStatusModal;


### PR DESCRIPTION




This PR adds a new CreateRequestStatusModal component that visually renders a modal to display the status of a request. The modal includes an icon (success or error), a message, and a background click handler to close the modal.

Changes

- Added the component and documentation.
- Added logic to dynamically display success or error icons based on the icon prop.
- Included a background click handler to close the modal when clicking outside the content.