### PR TITLE
add clinic comparison graph

### DIFF
--- a/src/components/ClinicComparisonGraph/ClinicComparison.stories.tsx
+++ b/src/components/ClinicComparisonGraph/ClinicComparison.stories.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import GraphCardVisualization from "./ClinicComparisonGraph";
+
+const meta: Meta<typeof GraphCardVisualization> = {
+  title: "Components/GraphCardVisualization",
+  component: GraphCardVisualization
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GraphCardVisualization>;
+
+export const Default: Story = {
+  args: {}
+};

--- a/src/components/ClinicComparisonGraph/ClinicComparison.tsx
+++ b/src/components/ClinicComparisonGraph/ClinicComparison.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from "react";
+import { LineChart, Line, ResponsiveContainer } from "recharts";
+import Button from "../Button/Button";
+
+interface ComparedClinic {
+  name: string;
+  location: string;
+  earnings: number;
+  trend: "up" | "down";
+  data: { value: number }[];
+}
+
+type Props = {
+  clinic: ComparedClinic;
+};
+
+const ClinicMiniCard: React.FC<Props> = ({ clinic }) => {
+  const arrow = clinic.trend === "up" ? "↑" : "↓";
+
+  const arrowColor = clinic.trend === "up" ? "text-green-500" : "text-red-500";
+
+  return (
+    <div className="flex items-center justify-between p-1 w-[320px] max-w-md">
+      <div>
+        <h2 className="text-lg font-bold">{clinic.name}</h2>
+        <p className="text-gray-600 text-sm">{clinic.location}</p>
+      </div>
+
+      <div className="w-20 h-12">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={clinic.data}>
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke={clinic.trend === "up" ? "#4CAF50" : "#F44336"}
+              strokeWidth={3}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="text-right">
+        <p className="text-xl font-bold">{clinic.earnings.toFixed(2)}</p>
+      </div>
+
+      <p className={`${arrowColor} text-sm p-2`}>{arrow}</p>
+    </div>
+  );
+};
+
+const ClinicComparisonGraph: React.FC = () => {
+  const clinics: ComparedClinic[] = [];
+  return (
+    <div className="flex flex-col gap-1 mx-4 p-5">
+      <h2 className="text-lg font-bold -mb-8">Clinic comparison</h2>
+      <p className="text-base mt-6 mb-8">Daily average</p>
+
+      {clinics.length === 0 ? (
+        <p className="text-center text-muted-foreground mb-4">
+          No clinics to compare available
+        </p>
+      ) : (
+        <>
+          {clinics.map((clinic, index) => (
+            <React.Fragment key={index}>
+              <ClinicMiniCard clinic={clinic} />
+              {index < clinics.length - 1 && (
+                <hr className="border-t border-gray-300 my-2" />
+              )}
+            </React.Fragment>
+          ))}
+        </>
+      )}
+
+      <div className="flex items-center justify-center mt-4">
+        <Button variant="blue" size="fill">
+          <p className="text-lg">Select clinic to compare</p>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ClinicComparisonGraph;

--- a/src/components/ClinicComparisonGraph/ClinicComparisonGraph.tsx
+++ b/src/components/ClinicComparisonGraph/ClinicComparisonGraph.tsx
@@ -1,0 +1,23 @@
+// components/PastTenantCard.tsx
+import { FC } from "react";
+import ClinicComparison from "./ClinicComparison";
+
+const GraphCard = ({ children }: { children: React.ReactNode }) => (
+  <div className="w-[380px] mt-4 h-[500px] flex items-center justify-center  p-2">
+    <div className="border rounded-lg my-1  shadow-sm  bg-white flex items-center flex-col justify-between w-full">
+      <div className="mt-4">{children}</div>
+    </div>
+  </div>
+);
+
+export default function GraphCardVisualization() {
+  return (
+    <div className="">
+      <div className="grid grid-cols-3 gap-12 p-12 items-start">
+        <GraphCard>
+          <ClinicComparison />
+        </GraphCard>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EarningsTimeGraph/EarningsTime.tsx
+++ b/src/components/EarningsTimeGraph/EarningsTime.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Button from "../Button/Button";
+import React from "react";
+import {
+  ComposedChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Bar,
+  Line,
+  ResponsiveContainer
+} from "recharts";
+
+export interface EarningsDataPoint {
+  label: string;
+  earnings: number;
+}
+
+export interface EarningsTimeGraphProps {
+  data: EarningsDataPoint[];
+  predictedPercentage: number;
+}
+
+
+
+const EarningsTimeGraph: React.FC<EarningsTimeGraphProps> = ({
+  data,
+  predictedPercentage
+}) => {
+  return (
+    <div className="p-2 w-[350px] flex flex-col items-center">
+      <h2 className="text-lg font-semibold mb-4">Earnings Over Time</h2>
+
+      {data.length === 0 ? (
+        <p className="text-muted-foreground text-sm text-center mt-10 mb-20">
+          No earnings data available.
+        </p>
+      ) : (
+        <>
+          <ResponsiveContainer width="105%" height={200} className="-ml-6">
+            <ComposedChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="label" />
+              <YAxis domain={[0, 50]} />
+              <Tooltip />
+              <Bar dataKey="earnings" barSize={20} fill="#E5E7EB" />
+              <Line
+                type="monotone"
+                dataKey="earnings"
+                stroke="#3B82F6"
+                strokeWidth={2}
+                dot
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+
+          <div className="mt-4 text-sm text-left ml-6">
+            <span className="text-xl text-left font-bold">
+              {predictedPercentage}%
+            </span>{" "}
+            Your sales performance is {predictedPercentage}% better compared to
+            last month
+          </div>
+        </>
+      )}
+
+      <div className="mt-4 flex gap-2">
+        <Button variant="blue" size="default">
+          Monthly
+        </Button>
+        <Button variant="blue" size="default">
+          Anual
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default EarningsTimeGraph;

--- a/src/components/EarningsTimeGraph/EarningsTimeGraph.stories.tsx
+++ b/src/components/EarningsTimeGraph/EarningsTimeGraph.stories.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import EarningsTimeGraph from "./EarningsTime";
+
+const meta: Meta<typeof EarningsTimeGraph> = {
+  title: "Components/EarningsTimeGraph",
+  component: EarningsTimeGraph,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EarningsTimeGraph>;
+
+const sampleEarningsData = [
+  { label: "Jan", earnings: 20 },
+  { label: "Feb", earnings: 25 },
+  { label: "Mar", earnings: 30 },
+  { label: "Apr", earnings: 45 },
+  { label: "May", earnings: 40 },
+  { label: "Jun", earnings: 42 },
+  { label: "Jul", earnings: 45 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleEarningsData,
+    predictedPercentage: 30,
+  },
+};
+
+export const WithPredictedData: Story = {
+  args: {
+    data: sampleEarningsData,
+    predictedPercentage: 50,
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    data: [],
+    predictedPercentage: 30,
+  },
+};

--- a/src/components/EarningsTimeGraph/EarningsTimeGraph.tsx
+++ b/src/components/EarningsTimeGraph/EarningsTimeGraph.tsx
@@ -1,0 +1,31 @@
+// Dashboard.tsx
+
+
+import { PastTenant } from "@/components/PastTenants/PastTenantCard";
+import PastTenantList from "@/components/PastTenants/PastTenantList";
+
+import EarningsTimeGraph from "./EarningsTime"
+
+const GraphCard = ({ children }: { children: React.ReactNode }) => (
+    <div className="w-[380px] mt-10 h-[500px] flex items-center justify-center  p-2">
+      <div className="border rounded-lg my-1  shadow-sm p-4 bg-white flex items-center flex-col justify-between w-full">
+        <div className="mt-4">{children}</div>
+      </div>
+    </div>
+  );
+
+  const sampleEarningsData = [];
+  export default function EarningsTimeVisualization() {
+    return (
+        <div className="grid-cols-1 md:grid-cols-3 gap-4">
+            <GraphCard >
+            <EarningsTimeGraph 
+          data={[]} 
+          predictedPercentage={30}
+        />
+            </GraphCard>
+   
+        </div>
+    );
+  }
+  


### PR DESCRIPTION
### Summary
This app adds a new ClinicComparison Graph component that visually represents a graph to the landlord user containing a comparison between their clinic and other nearby clinics, including colors and icons that change based on trends.

### Changes
Add ClinicComparison component, where the mini cards are rendered
Added ClinicComparisonGraph

### Test plan 
<img width="459" alt="Screenshot 2025-04-13 at 10 44 31 p m" src="https://github.com/user-attachments/assets/41a89e60-ba77-44b6-93cd-6323b0b5fa7a" />
