### PR TITLE
Feature: Add landlord rent request list page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "/**",
         search: ""
+      },
+      {
+        protocol: "https",
+        hostname: "firebasestorage.googleapis.com",
+        pathname: "/v0/b/**"
       }
     ]
   }

--- a/src/app/main/landlord/rent-requests/page.tsx
+++ b/src/app/main/landlord/rent-requests/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import LandlordRequestItem from "@/components/LandlordRequestItem";
+import { useRentRequests } from "@/hooks/useRentRequests";
+import { RentRequestPreview } from "@/types/rentRequestTypes";
+import { FaSpinner } from "react-icons/fa";
+
+export default function RentRequestsPage() {
+  const { rentRequests, loading } = useRentRequests();
+
+  return (
+    <main className="flex flex-col">
+      <div className="container mx-auto px-6 py-8">
+        <h2 className="font-bold text-2xl">Rent Requests</h2>
+
+        <div className="mt-12 ">
+          <RentRequestList
+            rentRequests={rentRequests}
+            loading={loading}
+            onClickAccept={(id) => console.log("Accept", id)}
+            onClickDeny={(id) => console.log("Deny", id)}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}
+
+interface RentRequestListProps {
+  rentRequests: RentRequestPreview[];
+  loading: boolean;
+  onClickAccept: (id: string) => void;
+  onClickDeny: (id: string) => void;
+}
+
+const RentRequestList = ({
+  rentRequests,
+  loading,
+  onClickAccept,
+  onClickDeny
+}: RentRequestListProps) => {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64 w-full">
+        <FaSpinner className="animate-spin text-gray-500 text-4xl" />
+      </div>
+    );
+  }
+  if (rentRequests.length === 0) {
+    return <div>No rent requests available.</div>;
+  }
+
+  return (
+    <div className="flex flex-col gap-10">
+      {rentRequests.map((request) => (
+        <LandlordRequestItem
+          key={request.id}
+          specialistName={request.tenantFullName}
+          date={request.startDate}
+          officeName={request.clinicDisplayName}
+          onClickAccept={() => onClickAccept(request.id)}
+          onClickDeny={() => onClickDeny(request.id)}
+          specialistPhoto={request.tenantProfilePictureUrl}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -21,6 +21,7 @@ const navbarLinks = {
   ],
   landlord: [
     { name: "Metrics", href: "/metrics" },
+    { name: "Rent Requests", href: "/main/landlord/rent-requests" },
     { name: "My Clinics", href: "/my-clinics" },
     { name: "New Clinic", href: "/main/landlord/create-clinic" },
     { name: "Past tenants", href: "/past-tenants" },

--- a/src/hooks/useRentRequests.ts
+++ b/src/hooks/useRentRequests.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import {
+  RENT_REQUEST_STATUS,
+  RentRequestPreview
+} from "@/types/rentRequestTypes";
+import { RentRequestService } from "@/services/RentRequestService";
+import { StorageService } from "@/services/StorageService";
+import { useAuth } from "./useAuth";
+
+export function useRentRequests() {
+  const [rentRequests, setRentRequests] = useState<RentRequestPreview[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!user) return;
+
+    const fetchRequests = async () => {
+      try {
+        setLoading(true);
+
+        const response = await RentRequestService.fetchRentRequestsByLandlord(
+          RENT_REQUEST_STATUS.PENDING
+        );
+
+        if (!response.success || !response.data) {
+          throw new Error("Failed to fetch rent requests");
+        }
+
+        const requestsWithPhotos = await Promise.all(
+          response.data.map(async (request) => {
+            try {
+              const profilePictureUrl = await StorageService.getFileUrl(
+                `profile_pictures/${request.tenantProfilePictureUrl}`
+              );
+
+              return {
+                ...request,
+                tenantProfilePictureUrl: profilePictureUrl
+              };
+            } catch {
+              return {
+                ...request,
+                tenantProfilePictureUrl: "/pfp_placeholder.png"
+              };
+            }
+          })
+        );
+
+        setRentRequests(requestsWithPhotos);
+      } catch (err) {
+        console.error("Error loading rent requests:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRequests();
+  }, [user]);
+
+  return { rentRequests, loading };
+}

--- a/src/services/RentRequestService.ts
+++ b/src/services/RentRequestService.ts
@@ -1,0 +1,33 @@
+import { ApiResponse } from "@/types/serviceTypes";
+import { AuthService } from "./AuthService";
+import axios from "axios";
+import { env } from "@/config/env";
+import {
+  RentRequestPreview,
+  RentRequestStatusType
+} from "@/types/rentRequestTypes";
+
+export class RentRequestService {
+  static BASE_URL = env.NEXT_PUBLIC_API_URL + "/rent-requests";
+
+  static async fetchRentRequestsByLandlord(
+    status: RentRequestStatusType
+  ): Promise<ApiResponse<RentRequestPreview[]>> {
+    try {
+      const headers = await AuthService.getAuthHeaders();
+
+      const params = new URLSearchParams();
+      params.append("status", status);
+      const response = await axios.get<ApiResponse<RentRequestPreview[]>>(
+        this.BASE_URL + "/landlord" + `?${params}`,
+        {
+          headers
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error("[RentRequestService]: Fetch rent requests error:", error);
+      throw error;
+    }
+  }
+}

--- a/src/types/rentRequestTypes.ts
+++ b/src/types/rentRequestTypes.ts
@@ -1,0 +1,20 @@
+export const RENT_REQUEST_STATUS = {
+  PENDING: "PENDING",
+  ACCEPTED: "ACCEPTED",
+  DENIED: "DENIED"
+};
+export type RentRequestStatusType =
+  (typeof RENT_REQUEST_STATUS)[keyof typeof RENT_REQUEST_STATUS];
+
+export interface RentRequestPreview {
+  id: string;
+  startDate: string;
+  endDate: string;
+  comments: string;
+  status: RentRequestStatusType;
+  tenantId: number;
+  clinicId: number;
+  clinicDisplayName: string;
+  tenantFullName: string;
+  tenantProfilePictureUrl: string;
+}


### PR DESCRIPTION
## Summary
This PR introduces a new landlord page to display all the rent requests associated to the logged in user, with pending status. It retrieves the data from the backend to display a list of `LandlordRentRequestItem` components.

## Test Plan

Loading
<img width="1733" alt="Captura de pantalla 2025-05-04 a la(s) 3 01 56 p m" src="https://github.com/user-attachments/assets/8280fd0d-5d40-4391-b7e0-870e486e0a9e" />

Default
<img width="1665" alt="Captura de pantalla 2025-05-04 a la(s) 3 02 16 p m" src="https://github.com/user-attachments/assets/ad59afbd-3966-4aea-b6c8-e5e59384902c" />

Empty
<img width="1627" alt="Captura de pantalla 2025-05-04 a la(s) 3 02 32 p m" src="https://github.com/user-attachments/assets/bd991f2c-8316-4bc6-84ea-d56e32541762" />

