### PR TITLE
Hotfix: Fix null error in storage service

### DIFF
--- a/src/hooks/useRentRequests.ts
+++ b/src/hooks/useRentRequests.ts
@@ -29,21 +29,14 @@ export function useRentRequests() {
 
         const requestsWithPhotos = await Promise.all(
           response.data.map(async (request) => {
-            try {
-              const profilePictureUrl = await StorageService.getFileUrl(
-                `profile_pictures/${request.tenantProfilePictureUrl}`
-              );
-
-              return {
-                ...request,
-                tenantProfilePictureUrl: profilePictureUrl
-              };
-            } catch {
-              return {
-                ...request,
-                tenantProfilePictureUrl: "/pfp_placeholder.png"
-              };
-            }
+            const profilePictureUrl = await StorageService.getFileUrl(
+              `profile_pictures/${request.tenantProfilePictureUrl}`
+            );
+            return {
+              ...request,
+              tenantProfilePictureUrl:
+                profilePictureUrl || "/pfp_placeholder.png"
+            };
           })
         );
 


### PR DESCRIPTION
## Summary
This PR updates the call to the storage service in the RentRequests component to solve null validation