### PR TITLE
Add Clinic Availability Times Feature

### DIFF
--- a/src/app/main/tenant/clinic-info/[id]/components/AvailabilitySection.tsx
+++ b/src/app/main/tenant/clinic-info/[id]/components/AvailabilitySection.tsx
@@ -1,0 +1,55 @@
+import { constToTitleCase } from "@/lib/textUtils";
+import { ClinicAvailability, WEEK_DAYS } from "@/types/clinicTypes";
+import React from "react";
+
+interface Props {
+  availabilities: ClinicAvailability[];
+}
+
+export default function AvailabilitySection({ availabilities }: Props) {
+  function formatTime(time: string) {
+    const [hours, minutes] = time.split(":").map(Number);
+    const ampm = hours >= 12 ? "PM" : "AM";
+    const formattedHours = hours % 12 || 12;
+    const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes;
+    return `${formattedHours}:${formattedMinutes} ${ampm}`;
+  }
+
+  const availabilityTimes = WEEK_DAYS.map((day, index) => {
+    const availability = availabilities?.filter((a) => a.weekDay === day);
+
+    if (availability?.length) {
+      return (
+        <div
+          key={index}
+          className="mb-4 rounded-xl border border-gray-300 bg-white p-5 shadow-sm "
+        >
+          <h3 className="text-lg font-semibold text-gray-800 mb-2">
+            {constToTitleCase(day)}
+          </h3>
+          <div className="space-y-1">
+            {availability.map((avail) => (
+              <div key={avail.id} className="text-sm text-gray-600">
+                <span className="font-medium text-gray-700">From:</span>{" "}
+                {formatTime(avail.startTime)}{" "}
+                <span className="font-medium text-gray-700">to</span>{" "}
+                {formatTime(avail.endTime)}
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
+    return null;
+  });
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-xl font-bold text-gray-900 mb-4">Available Times</h2>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {availabilityTimes}
+      </div>
+    </div>
+  );
+}

--- a/src/app/main/tenant/clinic-info/[id]/components/DescriptionSection.tsx
+++ b/src/app/main/tenant/clinic-info/[id]/components/DescriptionSection.tsx
@@ -7,6 +7,7 @@ interface Props {
 export default function DescriptionSection({ description }: Props) {
   return (
     <div className="mb-6">
+      <h2 className="text-xl font-bold text-gray-900 mb-4">Description</h2>
       <p className="text-gray-800 mb-2">
         {description ||
           `

--- a/src/app/main/tenant/clinic-info/[id]/components/ReserveCard.tsx
+++ b/src/app/main/tenant/clinic-info/[id]/components/ReserveCard.tsx
@@ -12,17 +12,24 @@ import { format } from "date-fns";
 import toast from "react-hot-toast";
 import Modal from "@/components/Modal";
 import TextInput from "@/components/TextInput";
+import { RentRequestService } from "@/services/RentRequestService";
 
 interface Props {
   costPerDay: number;
   clinicName: string;
   clinicId: number;
+  availibility: {
+    form: Date;
+    to: Date;
+    weekdays?: number[];
+  };
 }
 
 export default function ReserveCard({
   costPerDay,
   clinicName,
-  clinicId
+  clinicId,
+  availibility
 }: Props) {
   const [selectedDays, setSelectedDays] = useState<Date[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -49,12 +56,16 @@ export default function ReserveCard({
     setIsLoading(true);
     // Handle the reserve logic here
 
-    await new Promise((resolve) => setTimeout(resolve, 2000)); // Simulate a network request
-
-    toast.success("Reservation request sent successfully");
-    console.log("Reserved:", clinicId);
-    setIsLoading(false);
-    setIsOpen(false);
+    try {
+      await RentRequestService.sendRentRequest(clinicId, comment, selectedDays);
+      toast.success("Reservation request sent successfully");
+    } catch (error) {
+      console.error("Error  reservation request:", error);
+      toast.error("Failed to send reservation request");
+    } finally {
+      setIsLoading(false);
+      setIsOpen(false);
+    }
   }
 
   return (
@@ -173,6 +184,9 @@ export default function ReserveCard({
             <PopoverContent>
               <DatePicker
                 mode="multiple"
+                enabledDaysOfWeek={availibility.weekdays || []}
+                fromDate={availibility.form}
+                toDate={availibility.to}
                 selectedDate={selectedDays}
                 onSelectDate={(days) => {
                   setSelectedDays(days || []);

--- a/src/app/main/tenant/clinic-info/[id]/page.tsx
+++ b/src/app/main/tenant/clinic-info/[id]/page.tsx
@@ -7,6 +7,8 @@ import PhotoSection from "./components/PhotoSection";
 import EquipmentSection from "./components/EquipmentSection";
 import DescriptionSection from "./components/DescriptionSection";
 import { ClinicService } from "@/services/ClinicService";
+import { WEEK_DAY_NUMBERS } from "@/types/clinicTypes";
+import AvailabilitySection from "./components/AvailabilitySection";
 
 export default async function Page({
   params
@@ -43,10 +45,6 @@ export default async function Page({
         <div className="flex flex-wrap">
           {/* Left Content */}
           <div className="w-full lg:w-8/12 pr-0 lg:pr-6">
-            {/* Description */}
-
-            <DescriptionSection description={clinicData.description} />
-
             {/* Host */}
             <LandlodrdInfoSection
               landlordData={{
@@ -59,8 +57,14 @@ export default async function Page({
               }}
             />
 
+            {/* Description */}
+            <DescriptionSection description={clinicData.description} />
+
             {/* Amenities */}
             <EquipmentSection equipment={clinicData.equipments || []} />
+
+            {/* Availability */}
+            <AvailabilitySection availabilities={clinicData.availabilities!} />
 
             {/* Location */}
             <LocationSection
@@ -96,6 +100,14 @@ export default async function Page({
             costPerDay={clinicData.pricePerDay}
             clinicName={clinicData.displayName}
             clinicId={clinicData.id}
+            availibility={{
+              form: clinicData.availableFromDate,
+              to: clinicData.availableToDate,
+              weekdays:
+                clinicData.availabilities?.map(
+                  (a) => WEEK_DAY_NUMBERS[a.weekDay]
+                ) || []
+            }}
           />
         </div>
       </main>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -11,6 +11,7 @@ interface BaseProps {
   toDate?: Date;
   className?: ClassValue;
   disabledDates?: Date[];
+  enabledDaysOfWeek?: number[];
 }
 
 type Props =
@@ -37,8 +38,15 @@ export default function DatePicker({
   toDate,
   disabledDates,
   className,
-  selectedDate
+  selectedDate,
+  enabledDaysOfWeek = []
 }: Props) {
+  const allWeekDays = [0, 1, 2, 3, 4, 5, 6];
+
+  const disabledDaysOfWeek = allWeekDays.filter(
+    (day) => !enabledDaysOfWeek.includes(day)
+  );
+
   return (
     <div
       className={cn(
@@ -52,6 +60,9 @@ export default function DatePicker({
           selected={selectedDate}
           onSelect={onSelectDate}
           disabled={[
+            {
+              dayOfWeek: enabledDaysOfWeek.length > 0 ? disabledDaysOfWeek : []
+            },
             { before: fromDate, after: toDate } as Matcher,
             ...(disabledDates || [])
           ]}
@@ -63,6 +74,9 @@ export default function DatePicker({
           selected={selectedDate}
           onSelect={onSelectDate}
           disabled={[
+            {
+              dayOfWeek: enabledDaysOfWeek.length > 0 ? disabledDaysOfWeek : []
+            },
             { before: fromDate, after: toDate } as Matcher,
             ...(disabledDates || [])
           ]}
@@ -74,6 +88,9 @@ export default function DatePicker({
           selected={selectedDate}
           onSelect={onSelectDate}
           disabled={[
+            {
+              dayOfWeek: enabledDaysOfWeek.length > 0 ? disabledDaysOfWeek : []
+            },
             { before: fromDate, after: toDate } as Matcher,
             ...(disabledDates || [])
           ]}

--- a/src/services/RentRequestService.ts
+++ b/src/services/RentRequestService.ts
@@ -30,4 +30,27 @@ export class RentRequestService {
       throw error;
     }
   }
+
+  static async sendRentRequest(
+    clinicId: number,
+    comments: string,
+    dates: Date[]
+  ): Promise<void> {
+    try {
+      const headers = await AuthService.getAuthHeaders();
+
+      const body = {
+        clinicId,
+        comments,
+        dates: dates.map((date) => date.toISOString().split("T")[0])
+      };
+
+      await axios.post<ApiResponse<null>>(this.BASE_URL, body, {
+        headers
+      });
+    } catch (error) {
+      console.error("[RentRequestService]: Send rent request error:", error);
+      throw error;
+    }
+  }
 }

--- a/src/types/clinicTypes.ts
+++ b/src/types/clinicTypes.ts
@@ -20,6 +20,16 @@ export const CLINIC_EQUIPMENTS = [
 ] as const;
 export type ClinicEquipmentType = (typeof CLINIC_EQUIPMENTS)[number];
 
+export const WEEK_DAY_NUMBERS = {
+  MONDAY: 1,
+  TUESDAY: 2,
+  WEDNESDAY: 3,
+  THURSDAY: 4,
+  FRIDAY: 5,
+  SATURDAY: 6,
+  SUNDAY: 0
+} as const;
+
 export const WEEK_DAYS = [
   "MONDAY",
   "TUESDAY",


### PR DESCRIPTION
## Overview
This PR adds the ability to display clinic availability times on the clinic details page. Users can now view which days of the week and specific hours a clinic is available for booking.

## Changes
- Created new `AvailabilitySection` component to display clinic availability times
- Added weekday constants mapping in `clinicTypes.ts`
- Enhanced DatePicker component to support filtering by specific days of the week
- Implemented RentRequestService method to send rent requests with selected dates
- Fixed the positioning of the Description section in the clinic details page
- Updated ReserveCard to use the new availability data for date selection

## UI/UX Improvements
- Times are displayed in a clean, readable format (12-hour with AM/PM)
- Days with availability are shown in cards with times listed
- DatePicker now only allows selection of days that match the clinic's availability

## Screenshots
![image](https://github.com/user-attachments/assets/2754d9c5-41d1-4dfa-a7ec-df9deb6bd1f3)
