### PR TITLE
feature(clinics): add map section

### DIFF
--- a/src/app/main/landlord/create-clinic/components/BasicInfoSection.tsx
+++ b/src/app/main/landlord/create-clinic/components/BasicInfoSection.tsx
@@ -6,9 +6,13 @@ import {
 import TextInput from "@/components/TextInput";
 import SelectInput from "@/components/SelectInput/SelectInput";
 import { constToTitleCase } from "@/lib/textUtils";
+import MapInput from "../steps/../../../../../components/MapInput/MapInput";
 import toast from "react-hot-toast";
 import StepSectionBase, { StepSectionProps } from "./StepSectionBase";
 import ClinicEquipmentTag from "./ClinicEquipmentTag";
+import { useMapAddress } from "@/hooks/useMapAddress";
+import { Coordinates } from "@/hooks/useMapAddress";
+import { useEffect } from "react";
 
 export default function BasicInfoSection({
   onClickPrimary,
@@ -23,6 +27,16 @@ export default function BasicInfoSection({
     value: cat,
     name: constToTitleCase(cat)
   }));
+  const INITIAL_COORDS = {
+    latitude: 19.4326,
+    longitude: -99.1332
+  };
+  useEffect(() => {
+    setData("addressLatitude", INITIAL_COORDS.latitude);
+    setData("addressLongitude", INITIAL_COORDS.longitude);
+
+    setCoordsOnly(INITIAL_COORDS);
+  }, []);
 
   const DEFAULT_EQUIPMENT = "DEFAULT_SELECT";
   const equipmentsOptions = [
@@ -32,6 +46,30 @@ export default function BasicInfoSection({
       name: constToTitleCase(eq)
     }))
   ];
+  const {
+    coordinates,
+    address,
+    addressCity,
+    addressState,
+    addressZip,
+    addressCountry,
+    updateLocation: setCoordsOnly
+  } = useMapAddress(INITIAL_COORDS);
+  useEffect(() => {
+    if (address && address !== "Dirección no encontrada") {
+      setData("addressStreet", address);
+      setData("addressCity", addressCity);
+      setData("addressState", addressState);
+      setData("addressZip", addressZip);
+      setData("addressCountry", addressCountry);
+    }
+  }, [address]);
+
+  const updateLocation = (coords: Coordinates) => {
+    setData("addressLatitude", coords.latitude);
+    setData("addressLongitude", coords.longitude);
+    setCoordsOnly(coords);
+  };
 
   const handleAddEquipment = (eq: ClinicEquipmentType | "DEFAULT_SELECT") => {
     if (eq != DEFAULT_EQUIPMENT && !data.equipments?.includes(eq)) {
@@ -59,6 +97,19 @@ export default function BasicInfoSection({
       setError("size", "Size must be greater than 0");
       isValid = false;
     }
+
+    if (!data.addressStreet?.trim()) {
+      setError("addressStreet", "Address could not be determined");
+      isValid = false;
+    }
+    if (!data.addressZip?.trim()) {
+      setError("addressZip", "ZIP Code cannot be empty");
+      isValid = false;
+    } else if (!/^\d{5}$/.test(data.addressZip)) {
+      setError("addressZip", "ZIP Code must be exactly 5 digits");
+      isValid = false;
+    }
+    
     return isValid;
   };
 
@@ -114,7 +165,39 @@ export default function BasicInfoSection({
               isInvalid={!!errors.description}
             />
           </div>
-          <div className="flex-1">Map here</div>
+          <div className="flex-1 flex flex-col gap-4">
+            <div className="w-full h-[250px]">
+              <MapInput
+                onLocationChange={updateLocation}
+                className="w-full h-full rounded-lg "
+              />
+            </div>
+            <div className="flex gap-4">
+            <TextInput
+                  label="Address"
+                  value={data.addressStreet ?? ""}
+                  onChange={(e) => {
+                    clearError("addressStreet");
+                    setData("addressStreet", e.target.value);
+                  }}
+                  invalidMessage={errors.addressStreet}
+                  isInvalid={!!errors.addressStreet}
+                />
+              <div className="w-1/3">
+              <TextInput
+                label="ZIP Code"
+                value={data.addressZip ?? ""}
+                onChange={(e) => {
+                  clearError("addressZip");
+                  setData("addressZip", e.target.value);
+                }}
+                invalidMessage={errors.addressZip}
+                isInvalid={!!errors.addressZip}
+              />
+                
+              </div>
+            </div>
+          </div>
         </div>
         <div className="flex gap-12">
           <div className="flex-1">

--- a/src/hooks/useCreateClinicForm.ts
+++ b/src/hooks/useCreateClinicForm.ts
@@ -7,6 +7,8 @@ import {
   WEEK_DAYS
 } from "@/types/clinicTypes";
 import { useRouter } from "next/navigation";
+import { AxiosError } from "axios";
+
 import { useForm } from "./useForm";
 import { ClinicService } from "@/services/ClinicService";
 import { ClinicPhotoService } from "@/services/ClinicPhotoService";
@@ -18,6 +20,7 @@ import toast from "react-hot-toast";
 export type CreateClinicFormData = Partial<ClinicRegistrationData>;
 
 const ALLOWED_NUM_OF_PHOTOS = 4;
+
 
 const defaultData: CreateClinicFormData = {
   displayName: "",
@@ -36,7 +39,14 @@ const defaultData: CreateClinicFormData = {
   })),
   propertyProof: null,
   availableFromDate: null,
-  availableToDate: null
+  availableToDate: null,
+  addressStreet: "",
+  addressCity: "",
+  addressState: "",
+  addressZip: "",
+  addressCountry: "",
+  addressLatitude: 0,
+  addressLongitude: 0
 };
 
 export function useCreateClinicForm() {
@@ -71,9 +81,13 @@ export function useCreateClinicForm() {
     } catch (error) {
       console.error("[Clinic]: Error creating clinic", error);
       toast.error("Could not create all resources. Please try again");
+      const axiosError = error as AxiosError;
+      console.error("CREATE CLINIC ERROR STATUS:", axiosError.response?.status);
+      console.error("CREATE CLINIC ERROR DATA:", axiosError.response?.data);
+      throw error;    
     } finally {
       setIsSubmitting(false);
-      router.push("/main");
+      
     }
   };
 

--- a/src/hooks/useMapAddress.ts
+++ b/src/hooks/useMapAddress.ts
@@ -1,0 +1,52 @@
+import { useState } from "react";
+
+export type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+export function useMapAddress(initialCoords: Coordinates) {
+  const [coordinates, setCoordinates] = useState<Coordinates>(initialCoords);
+  const [address, setAddress] = useState("");
+  const [addressCity, setAddressCity] = useState("");
+  const [addressState, setAddressState] = useState("");
+  const [addressZip, setAddressZip] = useState("");
+  const [addressCountry, setAddressCountry] = useState("");
+
+  async function fetchAddressFromCoordinates(lat: number, lon: number) {
+    try {
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lon}`
+      );
+      const data = await res.json();
+      const addr = data?.address;
+
+      setAddress(data?.display_name ?? "Dirección no encontrada");
+      setAddressCity(addr?.city || addr?.town || addr?.village || "");
+      setAddressState(addr?.state || "");
+      setAddressZip(addr?.postcode || "");
+      setAddressCountry(addr?.country || "");
+    } catch {
+      setAddress("Dirección no encontrada");
+      setAddressCity("");
+      setAddressState("");
+      setAddressZip("");
+      setAddressCountry("");
+    }
+  }
+
+  async function updateLocation(newCoords: Coordinates) {
+    setCoordinates(newCoords);
+    await fetchAddressFromCoordinates(newCoords.latitude, newCoords.longitude);
+  }
+
+  return {
+    coordinates,
+    address,
+    addressCity,
+    addressState,
+    addressZip,
+    addressCountry,
+    updateLocation
+  };
+}

--- a/src/services/ClinicService.ts
+++ b/src/services/ClinicService.ts
@@ -17,6 +17,13 @@ export class ClinicService {
   static async createClinic(
     data: ClinicRegistrationData
   ): Promise<ApiResponse<Clinic>> {
+    const MAX_STREET_LENGTH = 255;
+    const street =
+      data.addressStreet.length > MAX_STREET_LENGTH
+        ? data.addressStreet.slice(0, MAX_STREET_LENGTH)
+        : data.addressStreet;
+        console.log("street", street)
+        const zip = data.addressZip?.trim() || "00000";
     const body = {
       displayName: data.displayName,
       category: data.category,
@@ -25,18 +32,17 @@ export class ClinicService {
       description: data.description,
       availableFromDate: data.availableFromDate,
       availableToDate: data.availableToDate,
-
-      // TODO: update address fields with the correct data
-      addressStreet: "Av hacker",
-      addressCity: "California",
-      addressState: "California",
-      addressZip: "123",
-      addressCountry: "USA",
-      addressLongitude: "134.234",
-      addressLatitude: "1234.23"
+      addressStreet: street,
+      addressCity: data.addressCity,
+      addressState: data.addressState,
+      addressZip: zip,
+      addressCountry: data.addressCountry,
+      addressLongitude: data.addressLongitude?.toString() ?? "",
+      addressLatitude:data.addressLatitude?.toString() ?? "",
     };
 
     const headers = await AuthService.getAuthHeaders();
+    console.log("CREATE CLINIC body:", body);
     return safeApiCall(
       () =>
         axios

--- a/src/types/clinicTypes.ts
+++ b/src/types/clinicTypes.ts
@@ -109,6 +109,13 @@ export interface ClinicRegistrationData {
   propertyProof: File | null;
   availableFromDate: Date | null;
   availableToDate: Date | null;
+  addressLatitude: number; 
+  addressLongitude: number; 
+  addressStreet: string
+  addressCity: string;
+  addressZip: string;
+  addressCountry: string;
+  addressState: string;
 }
 
 export interface ClinicDailyAvailabilityInput {


### PR DESCRIPTION
### Summary
This new PR added the logic and frontend to send the coordinates, latitude and longitude to the backend to create a new clinic, into the existent logic. A map input is included, where the user moves the pin and the latitude, longitude, city, country, zip code and street are  automatically filled. If the user wants, they can manually type the street and zip code. 

<img width="1512" alt="Screenshot 2025-05-12 at 1 16 32 a m" src="https://github.com/user-attachments/assets/e01e89a7-f427-43e4-8a2d-b5cb3bc863c0" />
