### PR TITLE
Feature/add rent request ocupied days

### DIFF
--- a/src/app/main/(shared)/clinic/[id]/components/ReserveCard.tsx
+++ b/src/app/main/(shared)/clinic/[id]/components/ReserveCard.tsx
@@ -22,6 +22,7 @@ interface Props {
     form: Date;
     to: Date;
     weekdays?: number[];
+    occupiedDates?: Date[];
   };
 }
 
@@ -188,6 +189,7 @@ export default function ReserveCard({
                 fromDate={availibility.form}
                 toDate={availibility.to}
                 selectedDate={selectedDays}
+                disabledDates={availibility.occupiedDates || []}
                 onSelectDate={(days) => {
                   setSelectedDays(days || []);
                 }}

--- a/src/app/main/(shared)/clinic/[id]/loading.tsx
+++ b/src/app/main/(shared)/clinic/[id]/loading.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+
+export default function loading() {
+  return (
+    <div className="max-w-6xl mx-auto font-sans animate-pulse">
+      <main className="p-4">
+        {/* Title Skeleton */}
+        <div className="mb-4">
+          <div className="h-8 w-2/3 bg-gray-200 rounded mb-2" />
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <div className="h-5 w-16 bg-gray-200 rounded" />
+              <div className="h-5 w-20 bg-gray-200 rounded" />
+            </div>
+            <div className="flex items-center space-x-4">
+              <div className="h-8 w-16 bg-gray-200 rounded" />
+              <div className="h-8 w-16 bg-gray-200 rounded" />
+            </div>
+          </div>
+        </div>
+
+        {/* Photo Gallery Skeleton */}
+        <div className="grid grid-cols-4 grid-rows-2 h-96 gap-2 mb-6">
+          <div className="col-span-2 row-span-2 bg-gray-200 rounded-l-lg" />
+          <div className="col-span-2 row-span-1 bg-gray-200 rounded-tr-lg" />
+          <div className="col-span-1 row-span-1 bg-gray-200" />
+          <div className="col-span-1 row-span-1 bg-gray-200 rounded-br-lg" />
+        </div>
+
+        <div className="flex flex-wrap">
+          {/* Main Content Skeleton */}
+          <div className="w-full lg:w-8/12 pr-0 lg:pr-6">
+            {/* Landlord Info Skeleton */}
+            <div className="flex items-start mb-6">
+              <div className="w-16 h-16 bg-gray-200 rounded-full mr-4" />
+              <div>
+                <div className="h-5 w-40 bg-gray-200 rounded mb-2" />
+                <div className="h-4 w-32 bg-gray-200 rounded mb-2" />
+                <div className="flex items-center space-x-4">
+                  <div className="h-4 w-16 bg-gray-200 rounded" />
+                  <div className="h-4 w-24 bg-gray-200 rounded" />
+                </div>
+              </div>
+            </div>
+
+            {/* Description Skeleton */}
+            <div className="mb-6">
+              <div className="h-6 w-32 bg-gray-200 rounded mb-4" />
+              <div className="h-4 w-full bg-gray-200 rounded mb-2" />
+              <div className="h-4 w-5/6 bg-gray-200 rounded" />
+            </div>
+
+            {/* Equipment Skeleton */}
+            <div className="mb-6">
+              <div className="h-6 w-48 bg-gray-200 rounded mb-4" />
+              <div className="grid grid-cols-2 gap-4">
+                {[...Array(4)].map((_, i) => (
+                  <div key={i} className="flex items-center space-x-2">
+                    <div className="w-6 h-6 bg-gray-200 rounded" />
+                    <div className="h-4 w-24 bg-gray-200 rounded" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Availability Skeleton */}
+            <div className="mt-6">
+              <div className="h-6 w-40 bg-gray-200 rounded mb-4" />
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {[...Array(3)].map((_, i) => (
+                  <div
+                    key={i}
+                    className="mb-4 rounded-xl border border-gray-200 bg-gray-100 p-5 shadow-sm"
+                  >
+                    <div className="h-5 w-24 bg-gray-200 rounded mb-2" />
+                    <div className="h-4 w-32 bg-gray-200 rounded mb-1" />
+                    <div className="h-4 w-20 bg-gray-200 rounded" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Location Skeleton */}
+            <div className="mb-6 mt-6">
+              <div className="h-6 w-32 bg-gray-200 rounded mb-4" />
+              <div className="h-64 bg-gray-200 rounded-lg" />
+            </div>
+
+            {/* Reviews Skeleton */}
+            <div className="mb-6">
+              <div className="h-6 w-64 bg-gray-200 rounded mb-4" />
+              <div className="flex items-center mb-4 space-x-2">
+                <div className="h-4 w-8 bg-gray-200 rounded" />
+                <div className="h-4 w-12 bg-gray-200 rounded" />
+                <div className="h-4 w-8 bg-gray-200 rounded" />
+                <div className="h-4 w-12 bg-gray-200 rounded" />
+              </div>
+              <div className="flex gap-4">
+                {[...Array(2)].map((_, i) => (
+                  <div key={i} className="flex-shrink-0 w-1/2">
+                    <div className="flex border border-gray-200 p-4 rounded-lg shadow-sm ml-1">
+                      <div className="mr-3 h-10 w-10 bg-gray-200 rounded-full" />
+                      <div className="flex flex-col flex-1">
+                        <div className="h-4 w-24 bg-gray-200 rounded mb-1" />
+                        <div className="h-3 w-16 bg-gray-200 rounded mb-1" />
+                        <div className="h-4 w-full bg-gray-200 rounded" />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Reserve Card Skeleton */}
+          <div className="w-full lg:w-4/12 mt-6 lg:mt-0">
+            <div className="border border-gray-200 rounded-lg p-6 shadow-md sticky top-6">
+              <div className="h-6 w-32 bg-gray-200 rounded mb-4" />
+              <div className="h-12 w-full bg-gray-200 rounded mb-4" />
+              <div className="h-10 w-full bg-gray-200 rounded mb-4" />
+              <div className="h-4 w-24 bg-gray-200 rounded mb-2" />
+              <div className="h-4 w-16 bg-gray-200 rounded mb-2" />
+              <div className="h-4 w-20 bg-gray-200 rounded" />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/main/(shared)/clinic/[id]/page.tsx
+++ b/src/app/main/(shared)/clinic/[id]/page.tsx
@@ -115,6 +115,7 @@ export default async function ClinicPage({
               availibility={{
                 form: clinicData.availableFromDate,
                 to: clinicData.availableToDate,
+                occupiedDates: clinicData.occupiedDates,
                 weekdays:
                   clinicData.availabilities?.map(
                     (a) => WEEK_DAY_NUMBERS[a.weekDay]

--- a/src/services/ClinicService.ts
+++ b/src/services/ClinicService.ts
@@ -22,8 +22,7 @@ export class ClinicService {
       data.addressStreet.length > MAX_STREET_LENGTH
         ? data.addressStreet.slice(0, MAX_STREET_LENGTH)
         : data.addressStreet;
-        console.log("street", street)
-        const zip = data.addressZip?.trim() || "00000";
+    const zip = data.addressZip?.trim() || "00000";
     const body = {
       displayName: data.displayName,
       category: data.category,
@@ -38,7 +37,7 @@ export class ClinicService {
       addressZip: zip,
       addressCountry: data.addressCountry,
       addressLongitude: data.addressLongitude?.toString() ?? "",
-      addressLatitude:data.addressLatitude?.toString() ?? "",
+      addressLatitude: data.addressLatitude?.toString() ?? ""
     };
 
     const headers = await AuthService.getAuthHeaders();
@@ -133,6 +132,22 @@ export class ClinicService {
       if (!response.data || !response.data.data) {
         return null;
       }
+
+      //Delete when endpoint is ready
+      const dates = [
+        //YYYY-MM-DD
+        "2025-05-02",
+        "2025-05-03",
+        "2025-05-04",
+        "2025-05-05",
+        "2025-05-06"
+      ];
+
+      const formattedDates = dates.map((date) => {
+        return new Date(date);
+      });
+      response.data.data.occupiedDates = formattedDates;
+      ///////
 
       return response.data.data;
     } catch (error) {

--- a/src/types/clinicTypes.ts
+++ b/src/types/clinicTypes.ts
@@ -67,6 +67,7 @@ export interface Clinic {
   photos?: ClinicPhoto[];
   equipments?: ClinicEquipment[];
   availabilities?: ClinicAvailability[];
+  occupiedDates?: Date[];
 }
 
 export interface ClinicPhoto {
@@ -109,9 +110,9 @@ export interface ClinicRegistrationData {
   propertyProof: File | null;
   availableFromDate: Date | null;
   availableToDate: Date | null;
-  addressLatitude: number; 
-  addressLongitude: number; 
-  addressStreet: string
+  addressLatitude: number;
+  addressLongitude: number;
+  addressStreet: string;
   addressCity: string;
   addressZip: string;
   addressCountry: string;


### PR DESCRIPTION
## Description
This PR adds the ability to display and handle occupied dates in the clinic rental system. When users view a clinic's availability and try to make a reservation, the system will now show days that are already booked/occupied, preventing double-bookings.

## Changes Made
- Added `ocupiedDates` optional property to the clinic interface
- Updated `ReserveCard.tsx` to pass occupied dates to the calendar component
- Added occupied dates handling in the reservation flow
- Added temporary mock occupied dates in `ClinicService.ts` for testing (to be replaced when the API endpoint is ready)
- Fixed minor code formatting issues
- Added clinic skeleton